### PR TITLE
client.js - edited global roles, ban & added mute object

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -796,7 +796,7 @@ var PlugAPI = function(authenticationData) {
 
     this.GLOBAL_ROLES = {
         NONE: 0,
-        AMBASSADOR: 2,
+        AMBASSADOR: 3,
         ADMIN: 5
     };
 
@@ -806,11 +806,17 @@ var PlugAPI = function(authenticationData) {
         WORKING: 2,
         GAMING: 3
     };
-
+  
     this.BAN = {
-        HOUR: 60,
-        DAY: 1440,
-        PERMA: -1
+        HOUR: "h",
+        DAY: "d",
+        PERMA: "f"
+    };
+
+    this.MUTE = {
+        SHORT: "s",
+        MEDIUM: "m",
+        LONG: "l"
     };
 
     this.events = eventTypes;


### PR DESCRIPTION
The ban object no longer contains integers (60, 1440 and -1) but strings instead, h(our),d(ay),f(orever).

I also added the MUTE object, same thing here, only strings, no integers.

The ambassador global role is 3 (manager) instead of 2 (bouncer).
