### PR TITLE
Fixed being unable to lock and unlock the booth without reloading the bot.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -875,6 +875,9 @@ function messageHandler(msg) {
             }, floodProtectionDelay * 5);
             logger.warning('Flood protection: Slowing down the sending of chat messages temporary');
             break;
+        case PlugAPI.events.DJ_LIST_LOCKED:
+            room.setBoothLocked(msg.p.f);
+            break;
         case PlugAPI.events.MODERATE_STAFF:
             //noinspection JSUnresolvedVariable
             for (i in data.u) {
@@ -1254,6 +1257,7 @@ PlugAPI.events = {
     COMMAND: 'command',
     DJ_LIST_CYCLE: 'djListCycle',
     DJ_LIST_UPDATE: 'djListUpdate',
+    DJ_LIST_LOCKED: 'djListLocked',
     EARN: 'earn',
     FOLLOW_JOIN: 'followJoin',
     FLOOD_CHAT: 'floodChat',

--- a/src/room.js
+++ b/src/room.js
@@ -422,6 +422,10 @@ Room.prototype.setRoomData = function(data) {
     votes = data.votes;
 };
 
+Room.prototype.setBoothLocked = function(data){
+    booth.isLocked = data;
+};
+
 Room.prototype.setDJs = function(djs) {
     booth.waitingDJs = djs;
 };


### PR DESCRIPTION
It wasn't possible to lock and unlock the booth in one session as the bot grabs the locked status of the booth when it joins but didn't update this status when the booth was either locked or unlocked.