### PR TITLE
Better async

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,16 @@ var PlugAPI = require('plugapi');
 new PlugAPI({
     email: '',
     password: ''
-}, function(bot) {
-    bot.connect('roomslug'); // The part after https://plug.dj
+}, function(err, bot) {
+    if (!err) {
+        bot.connect('roomslug'); // The part after https://plug.dj
 
-    bot.on('roomJoin', function(room) {
-        console.log("Joined " + room);
-    });
+        bot.on('roomJoin', function(room) {
+            console.log("Joined " + room);
+        });
+    } else {
+        console.log('Error initializing plugAPI: ' + err);
+    }
 });
 ```
 

--- a/src/client.js
+++ b/src/client.js
@@ -1386,7 +1386,7 @@ PlugAPI.prototype.emit = function() {
 PlugAPI.prototype.connect = function(roomSlug) {
     if (!roomSlug || typeof roomSlug !== 'string' || roomSlug.length === 0 || roomSlug.indexOf('/') > -1) {
         logger.error('Invalid room name');
-        process.exit(1);
+        return;
     }
 
     if (connectingRoomSlug != null) {

--- a/src/client.js
+++ b/src/client.js
@@ -1069,17 +1069,30 @@ function PerformLogin(callback, ignoreCache) {
  * @constructor
  */
 var PlugAPI = function(authenticationData, callback) {
+    if (typeof callback != 'function') {
+        callback = undefined;
+    }
+
     if (!authenticationData) {
         logger.error('You must pass the authentication data into the PlugAPI object to connect correctly');
-        process.exit(1);
+        if (callback) {
+            callback(new Error('You must pass the authentication data into the PlugAPI object to connect correctly'));
+        }
+        return;
     } else {
         if (!authenticationData.email) {
             logger.error('Missing login e-mail');
-            process.exit(1);
+            if (callback) {
+                callback(new Error('Missing login e-mail'));
+            }
+            return;
         }
         if (!authenticationData.password) {
             logger.error('Missing login password');
-            process.exit(1);
+            if (callback) {
+                callback(new Error('Missing login password'));
+            }
+            return;
         }
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -996,6 +996,7 @@ function PerformLoginCredentials(callback) {
             if (callback) {
                 callback(new Error('plugAPI login error: can\'t connect to plug.dj. HTTP Status: ' + res.statusCode));
             }
+            return;
         }
         try {
             _cookies.fromHeaders(res.headers);


### PR DESCRIPTION
This is meant to solve a few problems:
- Allow async usage to handle errors via the callback
- Get rid of all the calls to `process.exit`, as they definitely should not be present

As a consequence this changes the async callback params from `callback(plugapi)` to `callback(error, plugapi)`.

Also, affected file is `src/client.js` as opposed to `bin/client.js`.