### PR TITLE
fix moderateForceSkip skipping other users, fixes #91

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2144,7 +2144,7 @@ PlugAPI.prototype.moderateForceSkip = function(callback) {
     if (!room.getRoomMeta().slug || !this.havePermission(undefined, PlugAPI.ROOM_ROLE.BOUNCER) || room.getDJ() === null) {
         return false;
     }
-    if (!room.isDJ) {
+    if (!room.isDJ()) {
         queueREST('POST', endpoints.MODERATE_SKIP, {
             userID: room.getDJ().id,
             historyID: room.getHistoryID()


### PR DESCRIPTION
This bug was introduced when the selfSkip functionality was added.
isDJ is always defined, so the check ended up always going to the
selfSkip endpoint.