### PR TITLE
Fix: added check for success to PlugAPI.prototype.setLogger()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1703,7 +1703,7 @@ PlugAPI.prototype.getLoggerSettings = function() {
  * @returns {Boolean} True if set. False if not.
  */
 PlugAPI.prototype.setLogger = function(newLogger) {
-    var requiredMethods = ['info', 'warn', 'warning', 'error'];
+    var requiredMethods = ['info', 'warn', 'warning', 'error', 'success'];
 
     if (newLogger && typeof newLogger === 'object' && !Array.isArray(newLogger)) {
         for (var i in requiredMethods) {


### PR DESCRIPTION
`setLogger()` requires the new logger to have a `success` function, but didn't check if the new logger actually has a `success` function.

PlugAPI also exposes `logger.settings` via `PlugAPI.prototype.getLoggerSettings()`, which isn't checked for, but it isn't used internally. Some external scripts might rely on it, though.