### PR TITLE
Execute callback on booth join forbidden - Fixes #157

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -621,6 +621,9 @@ class PlugAPI extends EventEmitter3 {
                                 throw new Error(`${statusMessage} Can't join room.`);
                             });
                         } else if (Object.is(err.statusCode, 403)) {
+                            if (Object.is(err.url, 'https://plug.dj/_/booth')) {
+                                return sendCallback(err, null);
+                            }
                             process.nextTick(() => {
                                 throw new Error(`${opts.url} responded with ${err.statusCode} (${err.statusMessage}`);
                             });


### PR DESCRIPTION
Proposed patch for issue #157 
This will send the error to the callback rather than throw an exception.